### PR TITLE
backport 12-bit wrapping behavior

### DIFF
--- a/src/devices/sound/fm.cpp
+++ b/src/devices/sound/fm.cpp
@@ -2514,10 +2514,8 @@ static inline void ADPCMA_calc_chan( YM2610 *F2610, ADPCM_CH *ch )
 			ch->adpcm_acc += jedi_table[ch->adpcm_step + data];
 
 			/* extend 12-bit signed int */
-			if (ch->adpcm_acc & ~0x7ff)
+			if (ch->adpcm_acc & 0x800)
 				ch->adpcm_acc |= ~0xfff;
-			else
-				ch->adpcm_acc &= 0xfff;
 
 			ch->adpcm_step += step_inc[data & 7];
 			Limit( ch->adpcm_step, 48*16, 0*16 );

--- a/src/devices/sound/fm.cpp
+++ b/src/devices/sound/fm.cpp
@@ -2512,6 +2512,9 @@ static inline void ADPCMA_calc_chan( YM2610 *F2610, ADPCM_CH *ch )
 			ch->now_addr++;
 
 			ch->adpcm_acc += jedi_table[ch->adpcm_step + data];
+      
+			/* the 12-bit accumulator wraps on the ym2610 and ym2608 (like the msm5205), it does not saturate (like the msm5218 */
+			ch->adpcm_acc &= 0xfff;
 
 			/* extend 12-bit signed int */
 			if (ch->adpcm_acc & 0x800)


### PR DESCRIPTION
Thanks to Lord Nightmare for the heads-up. Fixes some glitches in certain samples in the metal slug series, and likely others.