### PR TITLE
Fix build on Python 3.9+

### DIFF
--- a/scripts/build/msgfmt.py
+++ b/scripts/build/msgfmt.py
@@ -112,7 +112,10 @@ def generate():
                          7*4,               # start of key index
                          7*4+len(keys)*8,   # start of value index
                          0, 0)              # size and offset of hash table
-    output += array.array("i", offsets).tostring()
+    if sys.version_info[1] >= 2:
+        output += array.array("i", offsets).tobytes()
+    else:
+        output += array.array("i", offsets).tostring()
     output += ids
     output += strs
     return output


### PR DESCRIPTION
When using `make PYTHON_EXECUTABLE=python3` the build fails when Python 3.9+ is being used. The reason is `array.array.tostring` method was deprecated since Python 3.2, finally removed on Python 3.9.