### PR TITLE
Main CPU Overclock Additional Values

### DIFF
--- a/src/osd/retro/libretro.cpp
+++ b/src/osd/retro/libretro.cpp
@@ -165,7 +165,7 @@ void retro_set_environment(retro_environment_t cb)
     { option_mouse, "Enable in-game mouse; disabled|enabled" },
     { option_throttle, "Enable throttle; disabled|enabled" },
     { option_cheats, "Enable cheats; disabled|enabled" },
-    { option_overclock, "Main CPU Overclock; default|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|60|65|70|75|80|85|90|95|100|105|110|115|120|125|130|135|140|145|150" },
+    { option_overclock, "Main CPU Overclock; default|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|60|65|70|75|80|85|90|95|100|105|110|115|120|125|130|135|140|145|150" },
     { option_renderer, "Alternate render method; disabled|enabled" },
 
     { option_softlist, "Enable softlists; enabled|disabled" },


### PR DESCRIPTION
On lower spec hardwares, such as Pi, Mini Classics, values 11-29 are detrimental in helping better run games like Deathsmiles, Outfoxies, Sega System 32 Games, etc., which are otherwise nearly impossible to run well!  I have had this implemented for awhile in MAME 2003 Xtreme, which really helps on Killer Instinct and Cruis'n USA!

Personal thanks pjft on 2016; grant2258 on 2003 Plus/Xtreme!