### PR TITLE
Fix GCC 14 and Python > 3.11 compile failures

### DIFF
--- a/3rdparty/rapidjson/include/rapidjson/document.h
+++ b/3rdparty/rapidjson/include/rapidjson/document.h
@@ -314,7 +314,7 @@ struct GenericStringRef {
 
     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
 
-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
+    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; /*length = rhs.length;*/ }
 
     //! implicit conversion to plain CharType pointer
     operator const Ch *() const { return s; }

--- a/src/devices/cpu/m6502/m6502make.py
+++ b/src/devices/cpu/m6502/m6502make.py
@@ -18,7 +18,7 @@ def load_opcodes(fname):
     opcodes = []
     logging.info("load_opcodes: %s", fname)
     try:
-        f = open(fname, "rU")
+        f = open(fname, "r")
     except Exception:
         err = sys.exc_info()[1]
         logging.error("cannot read opcodes file %s [%s]", fname, err)
@@ -41,7 +41,7 @@ def load_disp(fname):
     logging.info("load_disp: %s", fname)
     states = []
     try:
-        f = open(fname, "rU")
+        f = open(fname, "r")
     except Exception:
         err = sys.exc_info()[1]
         logging.error("cannot read display file %s [%s]", fname, err)

--- a/src/devices/cpu/m6809/m6809make.py
+++ b/src/devices/cpu/m6809/m6809make.py
@@ -16,7 +16,7 @@ def load_file(fname, lines):
 	if path != "":
 		path += '/'
 	try:
-		f = open(fname, "rU")
+		f = open(fname, "r")
 	except Exception:
 		err = sys.exc_info()[1]
 		sys.stderr.write("Cannot read opcodes file %s [%s]\n" % (fname, err))

--- a/src/devices/cpu/mcs96/mcs96make.py
+++ b/src/devices/cpu/mcs96/mcs96make.py
@@ -73,7 +73,7 @@ class OpcodeList:
         self.ea = {}
         self.macros = {}
         try:
-            f = open(fname, "rU")
+            f = open(fname, "r")
         except Exception:
             err = sys.exc_info()[1]
             sys.stderr.write("Cannot read opcodes file %s [%s]\n" % (fname, err))

--- a/src/devices/cpu/tms57002/tmsmake.py
+++ b/src/devices/cpu/tms57002/tmsmake.py
@@ -323,7 +323,7 @@ class Instruction:
 def LoadLst(filename):
     instructions = []
     ins = None
-    for n, line in enumerate(open(filename, "rU")):
+    for n, line in enumerate(open(filename, "r")):
         line = line.rstrip()
         if not line and ins:
             # new lines separate intructions

--- a/src/devices/machine/diablo_hd.cpp
+++ b/src/devices/machine/diablo_hd.cpp
@@ -1362,7 +1362,7 @@ void diablo_hd_device::device_reset()
 		m_pages = 2 * DIABLO_PAGES;
 	}
 	LOG_DRIVE((0,"[DHD%u]   m_handle            : %p\n", m_unit, m_handle));
-	LOG_DRIVE((0,"[DHD%u]   m_disk              : %p\n", m_unit, m_disk));
+	LOG_DRIVE((0,"[DHD%u]   m_disk              : %p\n", m_unit, static_cast<void*>(m_disk)));
 	LOG_DRIVE((0,"[DHD%u]   rotation time       : %.0fns\n", m_unit, m_rotation_time.as_double() * ATTOSECONDS_PER_NANOSECOND));
 	LOG_DRIVE((0,"[DHD%u]   sector time         : %.0fns\n", m_unit, m_sector_time.as_double() * ATTOSECONDS_PER_NANOSECOND));
 	LOG_DRIVE((0,"[DHD%u]   sector mark 0 time  : %.0fns\n", m_unit, m_sector_mark_0_time.as_double() * ATTOSECONDS_PER_NANOSECOND));


### PR DESCRIPTION
Needs to be tested

Fixes:
https://github.com/libretro/mame2016-libretro/issues/62
https://github.com/libretro/mame2016-libretro/issues/63

